### PR TITLE
Responsive refactor

### DIFF
--- a/app/(index)/Canvas.tsx
+++ b/app/(index)/Canvas.tsx
@@ -1,0 +1,19 @@
+import { Environment } from "@react-three/drei";
+import { Canvas as R3FCanvas } from "@react-three/fiber";
+
+import { ScrollableScene } from "./ScrollableScene";
+
+export const CAMERA_SETTINGS = { fov: 50 };
+
+const Canvas = () => {
+  return (
+    <R3FCanvas className="h-screen" camera={CAMERA_SETTINGS}>
+      <Environment files="/assets/abandoned-city.hdr" background blur={0.1} />
+      <directionalLight intensity={1.5} position={[4, 0, 5]} />
+
+      <ScrollableScene />
+    </R3FCanvas>
+  );
+};
+
+export default Canvas;

--- a/app/(index)/DescriptionSection.tsx
+++ b/app/(index)/DescriptionSection.tsx
@@ -2,12 +2,26 @@ import * as THREE from "three";
 
 import { useRef } from "react";
 
-import { Text, useScroll } from "@react-three/drei";
+import { Center, Text, useScroll } from "@react-three/drei";
 import { useFrame } from "@react-three/fiber";
+
+import { getViewportHeightAtDepth } from "@/app/utils";
+
+import { CAMERA_SETTINGS } from "./page";
+import { SCENE_MARGIN_X_TO_VIEWPORT_RATIO } from "./ScrollableScene";
 
 const DescriptionSection = () => {
   const scroll = useScroll();
   const descTextRef = useRef<THREE.Group | null>(null);
+
+  const sectionZ = 2;
+
+  const viewportHeight = getViewportHeightAtDepth(sectionZ, CAMERA_SETTINGS);
+  const viewportWidth =
+    viewportHeight * (window.innerWidth / window.innerHeight);
+  const marginX = viewportWidth * SCENE_MARGIN_X_TO_VIEWPORT_RATIO;
+
+  const sectionX = 0 + viewportWidth / 2 - marginX;
 
   useFrame(() => {
     if (descTextRef.current) {
@@ -17,7 +31,13 @@ const DescriptionSection = () => {
   });
 
   return (
-    <group ref={descTextRef} position={[0.4, 6.8, 2]}>
+    <Center
+      ref={descTextRef}
+      position={[sectionX, 0, sectionZ]}
+      precise={false}
+      left
+      onCentered={() => {}}
+    >
       <Text
         position={[0, 0.27, 0]}
         anchorX="left"
@@ -50,7 +70,7 @@ const DescriptionSection = () => {
         dark comedy converge in this NSFW anthology {`\n`}
         of animated stories.
       </Text>
-    </group>
+    </Center>
   );
 };
 

--- a/app/(index)/DescriptionSection.tsx
+++ b/app/(index)/DescriptionSection.tsx
@@ -7,7 +7,7 @@ import { useFrame } from "@react-three/fiber";
 
 import { getViewportHeightAtDepth } from "@/app/utils";
 
-import { CAMERA_SETTINGS } from "./page";
+import { CAMERA_SETTINGS } from "./Canvas";
 import { SCENE_MARGIN_X_TO_VIEWPORT_RATIO } from "./ScrollableScene";
 
 const DescriptionSection = () => {

--- a/app/(index)/DescriptionSection.tsx
+++ b/app/(index)/DescriptionSection.tsx
@@ -1,0 +1,57 @@
+import * as THREE from "three";
+
+import { useRef } from "react";
+
+import { Text, useScroll } from "@react-three/drei";
+import { useFrame } from "@react-three/fiber";
+
+const DescriptionSection = () => {
+  const scroll = useScroll();
+  const descTextRef = useRef<THREE.Group | null>(null);
+
+  useFrame(() => {
+    if (descTextRef.current) {
+      const translationOffset = scroll.range(38 / 100, 56 / 100);
+      descTextRef.current.position.y = 6.8 - 3.2 * translationOffset;
+    }
+  });
+
+  return (
+    <group ref={descTextRef} position={[0.4, 6.8, 2]}>
+      <Text
+        position={[0, 0.27, 0]}
+        anchorX="left"
+        color="white"
+        font="/fonts/Bebas-Regular.ttf"
+        fontSize={0.23}
+        letterSpacing={0.2}
+      >
+        Sci-Fi
+      </Text>
+      <Text
+        position={[0, 0, 0]}
+        anchorX="left"
+        color="white"
+        font="/fonts/Bebas-Regular.ttf"
+        fontSize={0.37}
+      >
+        Television
+      </Text>
+      <Text
+        position={[0, -0.35, 0]}
+        anchorX="left"
+        color="white"
+        font="/fonts/Bebas-Regular.ttf"
+        fontSize={0.07}
+        lineHeight={1.2}
+        letterSpacing={0.05}
+      >
+        Terrifying creatures, wicked surprised and {`\n`}
+        dark comedy converge in this NSFW anthology {`\n`}
+        of animated stories.
+      </Text>
+    </group>
+  );
+};
+
+export default DescriptionSection;

--- a/app/(index)/DescriptionSection.tsx
+++ b/app/(index)/DescriptionSection.tsx
@@ -12,7 +12,7 @@ import { SCENE_MARGIN_X_TO_VIEWPORT_RATIO } from "./ScrollableScene";
 
 const DescriptionSection = () => {
   const scroll = useScroll();
-  const descTextRef = useRef<THREE.Group | null>(null);
+  const descSectionRef = useRef<THREE.Group | null>(null);
 
   const sectionZ = 2;
 
@@ -22,17 +22,18 @@ const DescriptionSection = () => {
   const marginX = viewportWidth * SCENE_MARGIN_X_TO_VIEWPORT_RATIO;
 
   const sectionX = 0 + viewportWidth / 2 - marginX;
+  const sectionY = -viewportHeight / 2 - viewportHeight * 2.35;
 
   useFrame(() => {
-    if (descTextRef.current) {
-      const translationOffset = scroll.range(38 / 100, 56 / 100);
-      descTextRef.current.position.y = 6.8 - 3.2 * translationOffset;
+    if (descSectionRef.current) {
+      const dampFactor = 4 * scroll.range(1 / 2, 4 / 5);
+      descSectionRef.current.position.y = sectionY - dampFactor;
     }
   });
 
   return (
     <Center
-      ref={descTextRef}
+      ref={descSectionRef}
       position={[sectionX, 0, sectionZ]}
       precise={false}
       left

--- a/app/(index)/DescriptionSection.tsx
+++ b/app/(index)/DescriptionSection.tsx
@@ -19,7 +19,7 @@ const DescriptionSection = () => {
   const viewportHeight = getViewportHeightAtDepth(sectionZ, CAMERA_SETTINGS);
   const viewportWidth =
     viewportHeight * (window.innerWidth / window.innerHeight);
-  const marginX = viewportWidth * SCENE_MARGIN_X_TO_VIEWPORT_RATIO;
+  const marginX = viewportWidth * (SCENE_MARGIN_X_TO_VIEWPORT_RATIO + 0.1);
 
   const sectionX = 0 + viewportWidth / 2 - marginX;
   const sectionY = -viewportHeight / 2 - viewportHeight * 2.35;
@@ -56,7 +56,7 @@ const DescriptionSection = () => {
         font="/fonts/Bebas-Regular.ttf"
         fontSize={0.37}
       >
-        Television
+        Stories
       </Text>
       <Text
         position={[0, -0.35, 0]}
@@ -67,9 +67,9 @@ const DescriptionSection = () => {
         lineHeight={1.2}
         letterSpacing={0.05}
       >
-        Terrifying creatures, wicked surprised and {`\n`}
-        dark comedy converge in this NSFW anthology {`\n`}
-        of animated stories.
+        Terrifying creatures, wicked surprised {`\n`}
+        and dark comedy converge in this NSFW {`\n`}
+        anthology of animated stories.
       </Text>
     </Center>
   );

--- a/app/(index)/DirectorSection.tsx
+++ b/app/(index)/DirectorSection.tsx
@@ -5,9 +5,23 @@ import { useRef } from "react";
 import { Text, useScroll } from "@react-three/drei";
 import { useFrame } from "@react-three/fiber";
 
+import { getViewportHeightAtDepth } from "@/app/utils";
+
+import { CAMERA_SETTINGS } from "./page";
+import { SCENE_MARGIN_X_TO_VIEWPORT_RATIO } from "./ScrollableScene";
+
 const DirectorSection = () => {
   const scroll = useScroll();
   const directorTextRef = useRef<THREE.Group | null>(null);
+
+  const sectionZ = -3;
+
+  const viewportHeight = getViewportHeightAtDepth(sectionZ, CAMERA_SETTINGS);
+  const viewportWidth =
+    viewportHeight * (window.innerWidth / window.innerHeight);
+  const marginX = viewportWidth * SCENE_MARGIN_X_TO_VIEWPORT_RATIO;
+
+  const sectionX = 0 - viewportWidth / 2 + marginX;
 
   useFrame(() => {
     if (directorTextRef.current) {
@@ -17,7 +31,7 @@ const DirectorSection = () => {
   });
 
   return (
-    <group ref={directorTextRef} position={[-4.5, 7.2, -3]}>
+    <group ref={directorTextRef} position={[sectionX, 0, sectionZ]}>
       <Text
         position={[0, 0.62, 0]}
         anchorX="left"

--- a/app/(index)/DirectorSection.tsx
+++ b/app/(index)/DirectorSection.tsx
@@ -6,7 +6,7 @@ import { Text } from "@react-three/drei";
 
 import { getViewportHeightAtDepth } from "@/app/utils";
 
-import { CAMERA_SETTINGS } from "./page";
+import { CAMERA_SETTINGS } from "./Canvas";
 import { SCENE_MARGIN_X_TO_VIEWPORT_RATIO } from "./ScrollableScene";
 
 const DirectorSection = () => {

--- a/app/(index)/DirectorSection.tsx
+++ b/app/(index)/DirectorSection.tsx
@@ -2,8 +2,7 @@ import * as THREE from "three";
 
 import { useRef } from "react";
 
-import { Text, useScroll } from "@react-three/drei";
-import { useFrame } from "@react-three/fiber";
+import { Text } from "@react-three/drei";
 
 import { getViewportHeightAtDepth } from "@/app/utils";
 
@@ -11,7 +10,6 @@ import { CAMERA_SETTINGS } from "./page";
 import { SCENE_MARGIN_X_TO_VIEWPORT_RATIO } from "./ScrollableScene";
 
 const DirectorSection = () => {
-  const scroll = useScroll();
   const directorTextRef = useRef<THREE.Group | null>(null);
 
   const sectionZ = -3;
@@ -22,16 +20,10 @@ const DirectorSection = () => {
   const marginX = viewportWidth * SCENE_MARGIN_X_TO_VIEWPORT_RATIO;
 
   const sectionX = 0 - viewportWidth / 2 + marginX;
-
-  useFrame(() => {
-    if (directorTextRef.current) {
-      const translationOffset = scroll.range(15 / 100, 74 / 100);
-      directorTextRef.current.position.y = 7.2 + 2 * translationOffset;
-    }
-  });
+  const sectionY = -viewportHeight / 2 - viewportHeight * 0.25;
 
   return (
-    <group ref={directorTextRef} position={[sectionX, 0, sectionZ]}>
+    <group ref={directorTextRef} position={[sectionX, sectionY, sectionZ]}>
       <Text
         position={[0, 0.62, 0]}
         anchorX="left"

--- a/app/(index)/DirectorSection.tsx
+++ b/app/(index)/DirectorSection.tsx
@@ -1,0 +1,54 @@
+import * as THREE from "three";
+
+import { useRef } from "react";
+
+import { Text, useScroll } from "@react-three/drei";
+import { useFrame } from "@react-three/fiber";
+
+const DirectorSection = () => {
+  const scroll = useScroll();
+  const directorTextRef = useRef<THREE.Group | null>(null);
+
+  useFrame(() => {
+    if (directorTextRef.current) {
+      const translationOffset = scroll.range(15 / 100, 74 / 100);
+      directorTextRef.current.position.y = 7.2 + 2 * translationOffset;
+    }
+  });
+
+  return (
+    <group ref={directorTextRef} position={[-4.5, 7.2, -3]}>
+      <Text
+        position={[0, 0.62, 0]}
+        anchorX="left"
+        color="white"
+        font="/fonts/Bebas-Regular.ttf"
+        fontSize={0.18}
+        letterSpacing={0.55}
+      >
+        Created by
+      </Text>
+      <Text
+        position={[0, 0, 0]}
+        anchorX="left"
+        color="white"
+        font="/fonts/Bebas-Regular.ttf"
+        fontSize={0.6}
+        letterSpacing={0.2}
+      >
+        Tim
+      </Text>
+      <Text
+        position={[0, -0.72, 0]}
+        anchorX="left"
+        color="white"
+        font="/fonts/Bebas-Regular.ttf"
+        fontSize={1}
+      >
+        Miller
+      </Text>
+    </group>
+  );
+};
+
+export default DirectorSection;

--- a/app/(index)/DirectorSection.tsx
+++ b/app/(index)/DirectorSection.tsx
@@ -17,7 +17,7 @@ const DirectorSection = () => {
   const viewportHeight = getViewportHeightAtDepth(sectionZ, CAMERA_SETTINGS);
   const viewportWidth =
     viewportHeight * (window.innerWidth / window.innerHeight);
-  const marginX = viewportWidth * SCENE_MARGIN_X_TO_VIEWPORT_RATIO;
+  const marginX = viewportWidth * (SCENE_MARGIN_X_TO_VIEWPORT_RATIO + 0.1);
 
   const sectionX = 0 - viewportWidth / 2 + marginX;
   const sectionY = -viewportHeight / 2 - viewportHeight * 0.25;

--- a/app/(index)/Scene.tsx
+++ b/app/(index)/Scene.tsx
@@ -10,7 +10,12 @@ import { externalRoutes } from "../routes";
 
 import Xbot from "./Xbot";
 
-const Scene = () => {
+interface Props {
+  onCalculateXbotHeight?: (height: number) => void;
+}
+const Scene = (props: Props) => {
+  const { onCalculateXbotHeight } = props;
+
   const xbotRef = useRef<THREE.Group | null>(null);
 
   const directorTextRef = useRef<THREE.Group | null>(null);
@@ -45,7 +50,11 @@ const Scene = () => {
 
   return (
     <Scroll>
-      <Xbot ref={xbotRef} scale={0.25} />
+      <Xbot
+        ref={xbotRef}
+        scale={0.25}
+        onCalculateXbotHeight={onCalculateXbotHeight}
+      />
 
       <Svg
         position={[-4.91, 16, -3]}

--- a/app/(index)/Scene.tsx
+++ b/app/(index)/Scene.tsx
@@ -3,7 +3,7 @@ import * as THREE from "three";
 import { motion } from "framer-motion";
 import { useRef } from "react";
 
-import { Scroll, useScroll, Svg, Text, Html } from "@react-three/drei";
+import { Scroll, useScroll, Svg, Text, Html, Center } from "@react-three/drei";
 import { useFrame } from "@react-three/fiber";
 
 import { externalRoutes } from "../routes";
@@ -56,11 +56,13 @@ const Scene = (props: Props) => {
         onCalculateXbotHeight={onCalculateXbotHeight}
       />
 
-      <Svg
-        position={[-4.91, 16, -3]}
-        src="/assets/ldrTitleLogo.svg"
-        scale={0.132}
-      />
+      <Center position={[0, 0.5, -3]}>
+        <Svg
+          position={[0, 0, 0]}
+          src="/assets/ldrTitleLogo.svg"
+          scale={0.132}
+        />
+      </Center>
 
       <group ref={directorTextRef} position={[-4.5, 7.2, -3]}>
         <Text

--- a/app/(index)/Scene.tsx
+++ b/app/(index)/Scene.tsx
@@ -1,13 +1,13 @@
 import * as THREE from "three";
 
-import { motion } from "framer-motion";
 import { useRef } from "react";
 
-import { Scroll, useScroll, Svg, Text, Html, Center } from "@react-three/drei";
+import { Scroll, useScroll, Svg, Center } from "@react-three/drei";
 import { useFrame } from "@react-three/fiber";
 
-import { externalRoutes } from "../routes";
-
+import DescriptionSection from "./DescriptionSection";
+import DirectorSection from "./DirectorSection";
+import WatchNowSection from "./WatchNowSection";
 import Xbot from "./Xbot";
 
 interface Props {
@@ -17,11 +17,6 @@ const Scene = (props: Props) => {
   const { onCalculateXbotHeight } = props;
 
   const xbotRef = useRef<THREE.Group | null>(null);
-
-  const directorTextRef = useRef<THREE.Group | null>(null);
-  const descTextRef = useRef<THREE.Group | null>(null);
-  const watchTextRef = useRef<THREE.Group | null>(null);
-
   const scroll = useScroll();
 
   useFrame(() => {
@@ -30,21 +25,6 @@ const Scene = (props: Props) => {
         THREE.MathUtils.degToRad(-90) -
         THREE.MathUtils.degToRad(scroll.offset * 360);
       xbotRef.current.rotation.y = rotationOffset;
-    }
-
-    if (directorTextRef.current) {
-      const translationOffset = scroll.range(15 / 100, 74 / 100);
-      directorTextRef.current.position.y = 7.2 + 2 * translationOffset;
-    }
-
-    if (descTextRef.current) {
-      const translationOffset = scroll.range(38 / 100, 56 / 100);
-      descTextRef.current.position.y = 6.8 - 3.2 * translationOffset;
-    }
-
-    if (watchTextRef.current) {
-      const translationOffset = scroll.range(60 / 100, 40 / 100);
-      watchTextRef.current.position.y = 4.2 - 2.6 * translationOffset;
     }
   });
 
@@ -64,122 +44,9 @@ const Scene = (props: Props) => {
         />
       </Center>
 
-      <group ref={directorTextRef} position={[-4.5, 7.2, -3]}>
-        <Text
-          position={[0, 0.62, 0]}
-          anchorX="left"
-          color="white"
-          font="/fonts/Bebas-Regular.ttf"
-          fontSize={0.18}
-          letterSpacing={0.55}
-        >
-          Created by
-        </Text>
-        <Text
-          position={[0, 0, 0]}
-          anchorX="left"
-          color="white"
-          font="/fonts/Bebas-Regular.ttf"
-          fontSize={0.6}
-          letterSpacing={0.2}
-        >
-          Tim
-        </Text>
-        <Text
-          position={[0, -0.72, 0]}
-          anchorX="left"
-          color="white"
-          font="/fonts/Bebas-Regular.ttf"
-          fontSize={1}
-        >
-          Miller
-        </Text>
-      </group>
-
-      <group ref={descTextRef} position={[0.4, 6.8, 2]}>
-        <Text
-          position={[0, 0.27, 0]}
-          anchorX="left"
-          color="white"
-          font="/fonts/Bebas-Regular.ttf"
-          fontSize={0.23}
-          letterSpacing={0.2}
-        >
-          Sci-Fi
-        </Text>
-        <Text
-          position={[0, 0, 0]}
-          anchorX="left"
-          color="white"
-          font="/fonts/Bebas-Regular.ttf"
-          fontSize={0.37}
-        >
-          Television
-        </Text>
-        <Text
-          position={[0, -0.35, 0]}
-          anchorX="left"
-          color="white"
-          font="/fonts/Bebas-Regular.ttf"
-          fontSize={0.07}
-          lineHeight={1.2}
-          letterSpacing={0.05}
-        >
-          Terrifying creatures, wicked surprised and {`\n`}
-          dark comedy converge in this NSFW anthology {`\n`}
-          of animated stories.
-        </Text>
-      </group>
-
-      <group ref={watchTextRef} position={[-1.7, 0, 2]}>
-        <Text
-          position={[0, 0.23, 0]}
-          anchorX="left"
-          color="white"
-          font="/fonts/Bebas-Regular.ttf"
-          fontSize={0.07}
-          letterSpacing={0.55}
-        >
-          Watch online
-        </Text>
-        <Text
-          position={[0, 0, 0]}
-          anchorX="left"
-          color="white"
-          font="/fonts/Bebas-Regular.ttf"
-          fontSize={0.23}
-          letterSpacing={0.2}
-        >
-          Only on
-        </Text>
-        <Text
-          onClick={() => console.log("clicked")}
-          position={[0, -0.27, 0]}
-          anchorX="left"
-          color="white"
-          font="/fonts/Bebas-Regular.ttf"
-          fontSize={0.37}
-        >
-          Netflix
-        </Text>
-        <Html
-          transform
-          zIndexRange={[9, 0]}
-          scale={0.15}
-          position={[0.29, -0.65, 0]}
-        >
-          <motion.a
-            href={externalRoutes.netflixLDRTitle}
-            whileHover={{
-              backgroundColor: "var(--color-botred)",
-              color: "#fff",
-            }}
-            className="border-botgray text-botgray rounded-full border-2 border-solid bg-transparent px-10 py-3"
-          >
-            Watch now
-          </motion.a>
-        </Html>
-      </group>
+      <DirectorSection />
+      <DescriptionSection />
+      <WatchNowSection />
     </Scroll>
   );
 };

--- a/app/(index)/ScrollableScene.tsx
+++ b/app/(index)/ScrollableScene.tsx
@@ -1,0 +1,10 @@
+import { ScrollControls } from "@react-three/drei";
+import Scene from "./Scene";
+
+export const ScrollableScene = () => {
+  return (
+    <ScrollControls pages={1.93} damping={2}>
+      <Scene />
+    </ScrollControls>
+  );
+};

--- a/app/(index)/ScrollableScene.tsx
+++ b/app/(index)/ScrollableScene.tsx
@@ -19,7 +19,7 @@ export const ScrollableScene = () => {
   const onCalculateXbotHeight = (height: number) => setXbotHeight(height);
 
   return (
-    <ScrollControls pages={numPages} damping={2}>
+    <ScrollControls pages={numPages}>
       <Scene onCalculateXbotHeight={onCalculateXbotHeight} />
     </ScrollControls>
   );

--- a/app/(index)/ScrollableScene.tsx
+++ b/app/(index)/ScrollableScene.tsx
@@ -7,7 +7,7 @@ import Scene from "./Scene";
 
 export const SCENE_MARGIN_TOP = 0.4;
 export const SCENE_MARGIN_BOTTOM = 1.25;
-export const SCENE_MARGIN_X_TO_VIEWPORT_RATIO = 0.05;
+export const SCENE_MARGIN_X_TO_VIEWPORT_RATIO = 0.1;
 
 export const ScrollableScene = () => {
   const { viewport } = useThree();

--- a/app/(index)/ScrollableScene.tsx
+++ b/app/(index)/ScrollableScene.tsx
@@ -7,6 +7,7 @@ import Scene from "./Scene";
 
 export const SCENE_MARGIN_TOP = 0.4;
 export const SCENE_MARGIN_BOTTOM = 1.25;
+export const SCENE_MARGIN_X_TO_VIEWPORT_RATIO = 0.05;
 
 export const ScrollableScene = () => {
   const { viewport } = useThree();

--- a/app/(index)/ScrollableScene.tsx
+++ b/app/(index)/ScrollableScene.tsx
@@ -7,7 +7,7 @@ import Scene from "./Scene";
 
 export const SCENE_MARGIN_TOP = 0.4;
 export const SCENE_MARGIN_BOTTOM = 1.25;
-export const SCENE_MARGIN_X_TO_VIEWPORT_RATIO = 0.1;
+export const SCENE_MARGIN_X_TO_VIEWPORT_RATIO = 0.05;
 
 export const ScrollableScene = () => {
   const { viewport } = useThree();

--- a/app/(index)/ScrollableScene.tsx
+++ b/app/(index)/ScrollableScene.tsx
@@ -1,6 +1,8 @@
 import { ScrollControls } from "@react-three/drei";
 import Scene from "./Scene";
 
+export const SCENE_MARGIN_TOP = 0.4;
+
 export const ScrollableScene = () => {
   return (
     <ScrollControls pages={1.93} damping={2}>

--- a/app/(index)/ScrollableScene.tsx
+++ b/app/(index)/ScrollableScene.tsx
@@ -1,12 +1,25 @@
+import { useState } from "react";
+
 import { ScrollControls } from "@react-three/drei";
+import { useThree } from "@react-three/fiber";
+
 import Scene from "./Scene";
 
 export const SCENE_MARGIN_TOP = 0.4;
+export const SCENE_MARGIN_BOTTOM = 1.25;
 
 export const ScrollableScene = () => {
+  const { viewport } = useThree();
+  const [xbotHeight, setXbotHeight] = useState(0);
+
+  const numPages =
+    (xbotHeight + SCENE_MARGIN_TOP + SCENE_MARGIN_BOTTOM) / viewport.height;
+
+  const onCalculateXbotHeight = (height: number) => setXbotHeight(height);
+
   return (
-    <ScrollControls pages={1.93} damping={2}>
-      <Scene />
+    <ScrollControls pages={numPages} damping={2}>
+      <Scene onCalculateXbotHeight={onCalculateXbotHeight} />
     </ScrollControls>
   );
 };

--- a/app/(index)/WatchNowSection.tsx
+++ b/app/(index)/WatchNowSection.tsx
@@ -6,11 +6,24 @@ import { useRef } from "react";
 import { Text, useScroll, Html } from "@react-three/drei";
 import { useFrame } from "@react-three/fiber";
 
-import { externalRoutes } from "../routes";
+import { externalRoutes } from "@/app/routes";
+import { getViewportHeightAtDepth } from "@/app/utils";
+
+import { CAMERA_SETTINGS } from "./page";
+import { SCENE_MARGIN_X_TO_VIEWPORT_RATIO } from "./ScrollableScene";
 
 const WatchNowSection = () => {
   const scroll = useScroll();
   const watchTextRef = useRef<THREE.Group | null>(null);
+
+  const sectionZ = 2;
+
+  const viewportHeight = getViewportHeightAtDepth(sectionZ, CAMERA_SETTINGS);
+  const viewportWidth =
+    viewportHeight * (window.innerWidth / window.innerHeight);
+  const marginX = viewportWidth * SCENE_MARGIN_X_TO_VIEWPORT_RATIO;
+
+  const sectionX = 0 - viewportWidth / 2 + marginX;
 
   useFrame(() => {
     if (watchTextRef.current) {
@@ -20,7 +33,7 @@ const WatchNowSection = () => {
   });
 
   return (
-    <group ref={watchTextRef} position={[-1.7, 0, 2]}>
+    <group ref={watchTextRef} position={[sectionX, 0, sectionZ]}>
       <Text
         position={[0, 0.23, 0]}
         anchorX="left"

--- a/app/(index)/WatchNowSection.tsx
+++ b/app/(index)/WatchNowSection.tsx
@@ -1,0 +1,75 @@
+import * as THREE from "three";
+
+import { motion } from "framer-motion";
+import { useRef } from "react";
+
+import { Text, useScroll, Html } from "@react-three/drei";
+import { useFrame } from "@react-three/fiber";
+
+import { externalRoutes } from "../routes";
+
+const WatchNowSection = () => {
+  const scroll = useScroll();
+  const watchTextRef = useRef<THREE.Group | null>(null);
+
+  useFrame(() => {
+    if (watchTextRef.current) {
+      const translationOffset = scroll.range(60 / 100, 40 / 100);
+      watchTextRef.current.position.y = 4.2 - 2.6 * translationOffset;
+    }
+  });
+
+  return (
+    <group ref={watchTextRef} position={[-1.7, 0, 2]}>
+      <Text
+        position={[0, 0.23, 0]}
+        anchorX="left"
+        color="white"
+        font="/fonts/Bebas-Regular.ttf"
+        fontSize={0.07}
+        letterSpacing={0.55}
+      >
+        Watch online
+      </Text>
+      <Text
+        position={[0, 0, 0]}
+        anchorX="left"
+        color="white"
+        font="/fonts/Bebas-Regular.ttf"
+        fontSize={0.23}
+        letterSpacing={0.2}
+      >
+        Only on
+      </Text>
+      <Text
+        onClick={() => console.log("clicked")}
+        position={[0, -0.27, 0]}
+        anchorX="left"
+        color="white"
+        font="/fonts/Bebas-Regular.ttf"
+        fontSize={0.37}
+      >
+        Netflix
+      </Text>
+      <Html
+        transform
+        zIndexRange={[9, 0]}
+        scale={0.15}
+        position={[0.29, -0.65, 0]}
+      >
+        <motion.a
+          href={externalRoutes.netflixLDRTitle}
+          whileHover={{
+            backgroundColor: "var(--color-botred)",
+            color: "#fff",
+          }}
+          className="border-botgray text-botgray rounded-full border-2 border-solid bg-transparent px-10 py-3"
+        >
+          Watch now
+        </motion.a>
+      </Html>
+    </group>
+  );
+};
+
+export default WatchNowSection;

--- a/app/(index)/WatchNowSection.tsx
+++ b/app/(index)/WatchNowSection.tsx
@@ -21,7 +21,7 @@ const WatchNowSection = () => {
   const viewportHeight = getViewportHeightAtDepth(sectionZ, CAMERA_SETTINGS);
   const viewportWidth =
     viewportHeight * (window.innerWidth / window.innerHeight);
-  const marginX = viewportWidth * SCENE_MARGIN_X_TO_VIEWPORT_RATIO;
+  const marginX = viewportWidth * (SCENE_MARGIN_X_TO_VIEWPORT_RATIO + 0.1);
 
   const sectionX = 0 - viewportWidth / 2 + marginX;
   const sectionY = -viewportHeight / 2 - viewportHeight * 3.25;

--- a/app/(index)/WatchNowSection.tsx
+++ b/app/(index)/WatchNowSection.tsx
@@ -9,7 +9,7 @@ import { useFrame } from "@react-three/fiber";
 import { externalRoutes } from "@/app/routes";
 import { getViewportHeightAtDepth } from "@/app/utils";
 
-import { CAMERA_SETTINGS } from "./page";
+import { CAMERA_SETTINGS } from "./Canvas";
 import { SCENE_MARGIN_X_TO_VIEWPORT_RATIO } from "./ScrollableScene";
 
 const WatchNowSection = () => {

--- a/app/(index)/WatchNowSection.tsx
+++ b/app/(index)/WatchNowSection.tsx
@@ -14,7 +14,7 @@ import { SCENE_MARGIN_X_TO_VIEWPORT_RATIO } from "./ScrollableScene";
 
 const WatchNowSection = () => {
   const scroll = useScroll();
-  const watchTextRef = useRef<THREE.Group | null>(null);
+  const watchSectionRef = useRef<THREE.Group | null>(null);
 
   const sectionZ = 2;
 
@@ -24,16 +24,17 @@ const WatchNowSection = () => {
   const marginX = viewportWidth * SCENE_MARGIN_X_TO_VIEWPORT_RATIO;
 
   const sectionX = 0 - viewportWidth / 2 + marginX;
+  const sectionY = -viewportHeight / 2 - viewportHeight * 3.25;
 
   useFrame(() => {
-    if (watchTextRef.current) {
-      const translationOffset = scroll.range(60 / 100, 40 / 100);
-      watchTextRef.current.position.y = 4.2 - 2.6 * translationOffset;
+    if (watchSectionRef.current) {
+      const dampFactor = 4 * scroll.range(2 / 3, 1);
+      watchSectionRef.current.position.y = sectionY - dampFactor;
     }
   });
 
   return (
-    <group ref={watchTextRef} position={[sectionX, 0, sectionZ]}>
+    <group ref={watchSectionRef} position={[sectionX, 0, sectionZ]}>
       <Text
         position={[0, 0.23, 0]}
         anchorX="left"

--- a/app/(index)/Xbot.tsx
+++ b/app/(index)/Xbot.tsx
@@ -7,9 +7,14 @@ Title: XBOT 4000
 */
 
 import * as THREE from "three";
+
 import { ForwardedRef, forwardRef } from "react";
-import { useGLTF } from "@react-three/drei";
 import { GLTF } from "three-stdlib";
+
+import { useGLTF } from "@react-three/drei";
+import { useThree } from "@react-three/fiber";
+
+import { SCENE_MARGIN_TOP } from "./ScrollableScene";
 
 type GLTFResult = GLTF & {
   nodes: {
@@ -20,17 +25,33 @@ type GLTFResult = GLTF & {
   };
 };
 
+interface Props {
+  scale?: [x: number, y: number, z: number] | number;
+}
 const Xbot = (
-  props: JSX.IntrinsicElements["group"],
+  props: JSX.IntrinsicElements["group"] & Props,
   ref: ForwardedRef<THREE.Group>,
 ) => {
-  const { nodes, materials } = useGLTF("/assets/xbot_4000.glb") as GLTFResult;
+  const { scale } = props;
 
-  nodes.ROBOT_LOWPOLY_lambert2_0.geometry.center();
-  nodes.ROBOT_LOWPOLY_lambert2_0.geometry.translate(0, 30.5, 0);
+  const { nodes, materials } = useGLTF("/assets/xbot_4000.glb") as GLTFResult;
+  const { viewport } = useThree();
+
+  const xbotGeom = nodes.ROBOT_LOWPOLY_lambert2_0.geometry;
+
+  xbotGeom.center();
+  xbotGeom.computeBoundingBox();
+
+  const scaleY = Array.isArray(scale) ? scale[1] : scale;
+  const yScalingFactor = scaleY ?? 1;
+  const xbotHeight =
+    (xbotGeom.boundingBox!.max!.y - xbotGeom.boundingBox!.min!.y) *
+    yScalingFactor;
+
+  const xbotY = 0 - xbotHeight / 2 + viewport.height / 2 - SCENE_MARGIN_TOP;
 
   return (
-    <group {...props} ref={ref} dispose={null}>
+    <group {...props} ref={ref} dispose={null} position={[0, xbotY, 0]}>
       <mesh
         castShadow
         receiveShadow

--- a/app/(index)/Xbot.tsx
+++ b/app/(index)/Xbot.tsx
@@ -8,7 +8,7 @@ Title: XBOT 4000
 
 import * as THREE from "three";
 
-import { ForwardedRef, forwardRef } from "react";
+import { ForwardedRef, forwardRef, useEffect } from "react";
 import { GLTF } from "three-stdlib";
 
 import { useGLTF } from "@react-three/drei";
@@ -27,12 +27,13 @@ type GLTFResult = GLTF & {
 
 interface Props {
   scale?: [x: number, y: number, z: number] | number;
+  onCalculateXbotHeight?: (height: number) => void;
 }
 const Xbot = (
   props: JSX.IntrinsicElements["group"] & Props,
   ref: ForwardedRef<THREE.Group>,
 ) => {
-  const { scale } = props;
+  const { scale, onCalculateXbotHeight } = props;
 
   const { nodes, materials } = useGLTF("/assets/xbot_4000.glb") as GLTFResult;
   const { viewport } = useThree();
@@ -47,6 +48,12 @@ const Xbot = (
   const xbotHeight =
     (xbotGeom.boundingBox!.max!.y - xbotGeom.boundingBox!.min!.y) *
     yScalingFactor;
+
+  useEffect(() => {
+    if (onCalculateXbotHeight) {
+      onCalculateXbotHeight(xbotHeight);
+    }
+  });
 
   const xbotY = 0 - xbotHeight / 2 + viewport.height / 2 - SCENE_MARGIN_TOP;
 

--- a/app/(index)/page.tsx
+++ b/app/(index)/page.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import { Environment, ScrollControls } from "@react-three/drei";
+import { Environment } from "@react-three/drei";
 import { Canvas } from "@react-three/fiber";
 
-import Scene from "./Scene";
+import { ScrollableScene } from "./ScrollableScene";
 import TrailerModal from "./TrailerModal";
 
 export default function Home() {
@@ -16,9 +16,7 @@ export default function Home() {
         <Environment files="/assets/abandoned-city.hdr" background blur={0.1} />
         <directionalLight intensity={1.5} position={[4, 0, 5]} />
 
-        <ScrollControls pages={1.93} damping={2}>
-          <Scene />
-        </ScrollControls>
+        <ScrollableScene />
       </Canvas>
 
       <TrailerModal className="absolute bottom-10 left-[5%] z-10" />

--- a/app/(index)/page.tsx
+++ b/app/(index)/page.tsx
@@ -6,10 +6,12 @@ import { Canvas } from "@react-three/fiber";
 import { ScrollableScene } from "./ScrollableScene";
 import TrailerModal from "./TrailerModal";
 
+export const CAMERA_SETTINGS = { fov: 50 };
+
 export default function Home() {
   return (
     <>
-      <Canvas className="h-screen" camera={{ fov: 50 }}>
+      <Canvas className="h-screen" camera={CAMERA_SETTINGS}>
         <Environment files="/assets/abandoned-city.hdr" background blur={0.1} />
         <directionalLight intensity={1.5} position={[4, 0, 5]} />
 

--- a/app/(index)/page.tsx
+++ b/app/(index)/page.tsx
@@ -9,10 +9,7 @@ import TrailerModal from "./TrailerModal";
 export default function Home() {
   return (
     <>
-      <Canvas
-        className="h-screen"
-        camera={{ fov: 50, position: [0, 13.5, 5], rotation: [0, 0, 0] }}
-      >
+      <Canvas className="h-screen" camera={{ fov: 50 }}>
         <Environment files="/assets/abandoned-city.hdr" background blur={0.1} />
         <directionalLight intensity={1.5} position={[4, 0, 5]} />
 

--- a/app/(index)/page.tsx
+++ b/app/(index)/page.tsx
@@ -1,23 +1,12 @@
 "use client";
 
-import { Environment } from "@react-three/drei";
-import { Canvas } from "@react-three/fiber";
-
-import { ScrollableScene } from "./ScrollableScene";
+import Canvas from "./Canvas";
 import TrailerModal from "./TrailerModal";
-
-export const CAMERA_SETTINGS = { fov: 50 };
 
 export default function Home() {
   return (
     <>
-      <Canvas className="h-screen" camera={CAMERA_SETTINGS}>
-        <Environment files="/assets/abandoned-city.hdr" background blur={0.1} />
-        <directionalLight intensity={1.5} position={[4, 0, 5]} />
-
-        <ScrollableScene />
-      </Canvas>
-
+      <Canvas />
       <TrailerModal className="absolute bottom-10 left-[5%] z-10" />
     </>
   );

--- a/app/utils.ts
+++ b/app/utils.ts
@@ -1,0 +1,35 @@
+const r3fCameraDefaults = {
+  fov: 75,
+  near: 0.1,
+  far: 1000,
+  position: [0, 0, 5],
+};
+
+export const getViewportHeightAtDepth = (
+  depth: number,
+  camera: { fov?: number; position?: [x: number, y: number, z: number] } = {},
+) => {
+  const defaults = r3fCameraDefaults;
+
+  // compensate for cameras not positioned at z=0
+  const cameraPostion = camera.position ?? defaults.position;
+  const cameraOffset = cameraPostion[2];
+  if (depth < cameraOffset) depth -= cameraOffset;
+  else depth += cameraOffset;
+
+  // vertical fov in radians
+  const fov = camera.fov ?? defaults.fov;
+  const vFov = (fov * Math.PI) / 180;
+
+  // Math.abs to ensure the result is always positive
+  return 2 * Math.tan(vFov / 2) * Math.abs(depth);
+};
+
+export const getViewportWidthAtDepth = (
+  depth: number,
+  aspect: number,
+  camera: { fov?: number; position?: [x: number, y: number, z: number] } = {},
+) => {
+  const height = getViewportHeightAtDepth(depth, camera);
+  return height * aspect;
+};


### PR DESCRIPTION
Refactors entire scene to be responsive in different viewports.
1. Recenter camera back to default position on the x, y origin. This makes calculating viewport height/width at different depths much simpler.
2. Update y positions of all elements (XBOT, title, info section) relative to this new origin. Use bounding boxes and viewport measurements to programmatically determine these positions where possible and eliminate magic numbers.
3. Update x positions of all elements relative to the screen width -> edge. This value changes based on element's depth.
4. Rework the damping logic for the info sections to eliminate magic numbers are work with new origin.